### PR TITLE
fix: resolve absolute paths for PDF generation, config, and excel loading

### DIFF
--- a/reports/pdf_builder.py
+++ b/reports/pdf_builder.py
@@ -1,4 +1,5 @@
 import os
+import re
 from datetime import datetime
 from fpdf import FPDF
 from fpdf.enums import XPos, YPos
@@ -22,15 +23,19 @@ def gerar_pdf_rota(cidade, ponto_partida, distancia_total, tempo_total_min,
     pdf.alias_nb_pages()
     pdf.add_page()
 
-    if os.path.exists("./assets/logo.png"):
-        pdf.image("./assets/logo.png", x=170, y=10, w=31.5)
+    base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    logo_path = os.path.join(base_dir, "assets", "logo.png")
+    if os.path.exists(logo_path):
+        pdf.image(logo_path, x=170, y=10, w=31.5)
 
     pdf.set_font("Helvetica", "B", 16)
     data_atual = datetime.now().strftime("%d/%m/%Y")
     titulo = f"Rota de Entregas - {cidade}"
 
-    nome_arquivo = remover_acentos(f"{datetime.now().strftime('%Y-%m-%d')} - Rota de Entregas - {cidade}").replace("/", "-")
-    pasta_rotas = "ROTAS-GERADAS"
+    cidade_segura = re.sub(r'[\\/*?:"<>|]', "", cidade)
+    nome_arquivo = remover_acentos(f"{datetime.now().strftime('%Y-%m-%d')} - Rota de Entregas - {cidade_segura}").replace("/", "-")
+
+    pasta_rotas = os.path.join(base_dir, "ROTAS-GERADAS")
     if not os.path.exists(pasta_rotas): os.makedirs(pasta_rotas)
     arquivo_saida_pdf = os.path.join(pasta_rotas, f"{nome_arquivo}.pdf")
 
@@ -159,4 +164,4 @@ def gerar_pdf_rota(cidade, ponto_partida, distancia_total, tempo_total_min,
             pdf.cell(50, 8, str(motivo)[:30], border=1, new_x=XPos.LMARGIN, new_y=YPos.NEXT, align="L")
 
     pdf.output(arquivo_saida_pdf)
-    print_colorido(f"\n✅ PDF gerado com sucesso: {arquivo_saida_pdf}", Fore.GREEN)
+    print_colorido(f"\n✅ PDF gerado com sucesso: {os.path.abspath(arquivo_saida_pdf)}", Fore.GREEN)

--- a/rota.py
+++ b/rota.py
@@ -20,6 +20,11 @@ from reports.pdf_builder import gerar_pdf_rota
 def main():
     config = carregar_config()
     arquivo_excel = config.get("arquivo_excel", "ENDERECOS-ROTA.xlsx")
+
+    # Ensure arquivo_excel is an absolute path based on the project root
+    if not os.path.isabs(arquivo_excel):
+        base_dir = os.path.dirname(os.path.abspath(__file__))
+        arquivo_excel = os.path.join(base_dir, arquivo_excel)
     nome_coluna_enderecos = config.get("nome_coluna_enderecos", "Endereco")
     nome_coluna_nomes = config.get("nome_coluna_nomes", "Nome")
     ponto_partida_bruto = config.get("ponto_partida", "Rua Floriano Peixoto, 368, Centro, Itapuí - SP")

--- a/utils/config_loader.py
+++ b/utils/config_loader.py
@@ -1,10 +1,13 @@
 import json
+import os
 from utils.console import print_colorido, Fore
 
 def carregar_config():
+    base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    config_path = os.path.join(base_dir, "config.json")
     try:
-        with open("config.json", 'r', encoding='utf-8') as f:
+        with open(config_path, 'r', encoding='utf-8') as f:
             return json.load(f)
     except FileNotFoundError:
-        print_colorido("❌ Erro: 'config.json' não encontrado.", Fore.RED)
+        print_colorido(f"❌ Erro: '{config_path}' não encontrado.", Fore.RED)
         exit(1)


### PR DESCRIPTION
Fixes an issue where the generated PDF might not be saved to the expected location or fails silently when run from different directories.
- Fixes `config.json` path loading by calculating absolute paths based on the file location.
- Fixes the `ENDERECOS-ROTA.xlsx` loaded via relative path by resolving to the absolute base directory.
- Fixes the `assets/logo.png` reading correctly.
- Fixes the `ROTAS-GERADAS` folder absolute output base path.
- Fixes file-writing errors gracefully by stripping illegal characters out of user-provided city names before saving them as part of the filename.

---
*PR created automatically by Jules for task [15813818492410060229](https://jules.google.com/task/15813818492410060229) started by @juniorchiodi*