### PR TITLE
Fix starting point outlier detection in routing

### DIFF
--- a/core/routing.py
+++ b/core/routing.py
@@ -79,7 +79,15 @@ def identificar_outliers(dist_matrix, enderecos_validos, limite_desvio=2.5, p80_
         media_ponto = sum(dist_ponto) / len(dist_ponto)
         p80 = sorted(dist_ponto)[max(0, min(len(dist_ponto) - 1, int(0.8 * (len(dist_ponto) - 1))))]
 
-        if (media_ponto > media + (limite_desvio * desvio)) or (p80 > p80_limite_km):
+        is_outlier = False
+        if i == 0:
+            if p80 > p80_limite_km:
+                is_outlier = True
+        else:
+            if (media_ponto > media + (limite_desvio * desvio)) or (p80 > p80_limite_km):
+                is_outlier = True
+
+        if is_outlier:
             outliers.append(i)
             print_colorido(f"Ponto identificado como outlier: {enderecos_validos[i]}", Fore.YELLOW)
         else:


### PR DESCRIPTION
The issue description reported that the starting point was consistently being identified as an outlier, preventing the route generation and PDF creation. The routing algorithm mistakenly used average distance standard deviation bounds on the starting point.

This fix specifically modifies `identificar_outliers` in `core/routing.py`. Now, the initial starting point (index 0) ignores the standard deviation check. Instead, it is solely verified against an absolute physical threshold (e.g., if the 80th percentile of its distances exceeds a maximum limit). This ensures we do not throw out the valid starting point purely due to statistical variance compared to tightly clustered end points.

---
*PR created automatically by Jules for task [4240218019339696297](https://jules.google.com/task/4240218019339696297) started by @juniorchiodi*