### PR TITLE
Fix silent errors in routing outlier detection

### DIFF
--- a/core/routing.py
+++ b/core/routing.py
@@ -74,7 +74,10 @@ def identificar_outliers(dist_matrix, enderecos_validos, limite_desvio=2.5, p80_
 
     for i in range(n):
         dist_ponto = [dist_matrix[i][j] for j in range(n) if i != j and dist_matrix[i][j] != float('inf')]
-        if not dist_ponto: continue
+        if not dist_ponto:
+            outliers.append(i)
+            print_colorido(f"Ponto identificado como outlier (isolado): {enderecos_validos[i]}", Fore.YELLOW)
+            continue
 
         media_ponto = sum(dist_ponto) / len(dist_ponto)
         p80 = sorted(dist_ponto)[max(0, min(len(dist_ponto) - 1, int(0.8 * (len(dist_ponto) - 1))))]

--- a/rota.py
+++ b/rota.py
@@ -112,7 +112,9 @@ def main():
                 linha_excel = nomes.index(nomes_validos[idx]) + 1 if nomes_validos[idx] in nomes else 0
                 enderecos_com_erro.append((linha_excel, enderecos_validos[idx], "Coordenada em outra cidade (Outlier)"))
             
-            if 0 in outliers_idx: exit(1)
+            if 0 in outliers_idx:
+                print_colorido("❌ Ponto de partida muito distante (outlier extremo). Encerrando para evitar rota impossível.", Fore.RED)
+                exit(1)
             coordenadas = [coordenadas[i] for i in pontos_principais]
             enderecos_validos = [enderecos_validos[i] for i in pontos_principais]
             nomes_validos = [nomes_validos[i] for i in pontos_principais] 


### PR DESCRIPTION
Fixed two issues related to outlier detection:
1. Isolated points (where `dist_ponto` is empty) were previously skipped using `continue`, causing them to disappear silently from both `pontos_principais` and `outliers`. They are now explicitly appended to the `outliers` list.
2. In `rota.py`, when the start point (index 0) was flagged as an extreme outlier, the script exited with `exit(1)` silently. Added an explicit, user-friendly `print_colorido` error message to explain the termination.

---
*PR created automatically by Jules for task [1352310862856797203](https://jules.google.com/task/1352310862856797203) started by @juniorchiodi*