### PR TITLE
Fix city duplication in Maps links

### DIFF
--- a/rota.py
+++ b/rota.py
@@ -161,7 +161,7 @@ def main():
             if is_coordenada(enderecos_validos[i]):
                 links.append(f"https://www.google.com/maps/place/{coordenadas[i][0]},{coordenadas[i][1]}")
             else:
-                end_url = quote(f"{enderecos_validos[i]}, {extrair_cidade(enderecos_validos[i])}")
+                end_url = quote(enderecos_validos[i])
                 links.append(f"https://www.google.com/maps/search/?api=1&query={end_url}")
 
         # --- 6. Relatórios (QR e PDF) ---


### PR DESCRIPTION
Resolves an issue where the generated PDF links for Google Maps had duplicated city names, which caused mapping glitches. Also ensures compatibility with future inputs that include neighborhood definitions.

---
*PR created automatically by Jules for task [14808916523090776560](https://jules.google.com/task/14808916523090776560) started by @juniorchiodi*